### PR TITLE
Update 06-managing-content-automation-hub.adoc

### DIFF
--- a/documentation/modules/ROOT/pages/06-managing-content-automation-hub.adoc
+++ b/documentation/modules/ROOT/pages/06-managing-content-automation-hub.adoc
@@ -158,18 +158,18 @@ dependencies:
 options:
   package_manager_path: /usr/bin/microdnf
 
-additional_build_steps: prepend_galaxy:
-  - ARG TOKEN
-  - ENV ANSIBLE_GALAXY_SERVER_LIST='published,certified,validated,community'
-  - ENV ANSIBLE_GALAXY_SERVER_CERTIFIED_URL='https://aap.example.com/pulp_ansible/galaxy/rh-certified/'
-  - ENV ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN=$TOKEN
-  - ENV ANSIBLE_GALAXY_SERVER_VALIDATED_URL='https://aap.example.com/pulp_ansible/galaxy/validated/'
-  - ENV ANSIBLE_GALAXY_SERVER_VALIDATED_TOKEN=$TOKEN
-  - ENV ANSIBLE_GALAXY_SERVER_COMMUNITY_URL='https://aap.example.com/pulp_ansible/galaxy/community/'
-  - ENV ANSIBLE_GALAXY_SERVER_COMMUNITY_TOKEN=$TOKEN
-  - ENV ANSIBLE_GALAXY_SERVER_PUBLISHED_URL='https://aap.example.com/pulp_ansible/galaxy/published/'
-  - ENV ANSIBLE_GALAXY_SERVER_PUBLISHED_TOKEN=$TOKEN
-
+additional_build_steps:
+  prepend_galaxy:
+    - ARG TOKEN
+    - ENV ANSIBLE_GALAXY_SERVER_LIST='published,certified,validated,community'
+    - ENV ANSIBLE_GALAXY_SERVER_CERTIFIED_URL='https://aap.example.com/pulp_ansible/galaxy/rh-certified/'
+    - ENV ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN=$TOKEN
+    - ENV ANSIBLE_GALAXY_SERVER_VALIDATED_URL='https://aap.example.com/pulp_ansible/galaxy/validated/'
+    - ENV ANSIBLE_GALAXY_SERVER_VALIDATED_TOKEN=$TOKEN
+    - ENV ANSIBLE_GALAXY_SERVER_COMMUNITY_URL='https://aap.example.com/pulp_ansible/galaxy/community/'
+    - ENV ANSIBLE_GALAXY_SERVER_COMMUNITY_TOKEN=$TOKEN
+    - ENV ANSIBLE_GALAXY_SERVER_PUBLISHED_URL='https://aap.example.com/pulp_ansible/galaxy/published/'
+    - ENV ANSIBLE_GALAXY_SERVER_PUBLISHED_TOKEN=$TOKEN
 ----
 
 NOTE: Replace the following values `pah.example.com` With the URL of your Private Automation Hub.


### PR DESCRIPTION
@djdanielsson 

- Changed namespace from `automation_bootcamp` to `ansible_bootcamp`, that will line up with the CI/CD lab. 
- Updated generate token text